### PR TITLE
Small fix

### DIFF
--- a/website/static/download/flapjax-2.1.js
+++ b/website/static/download/flapjax-2.1.js
@@ -517,7 +517,7 @@ EventStream.prototype.skipFirstE = function() {
     if (skipped)
       { return pulse; }
     else
-      { return doNotPropagate; }
+      { skipped = true; return doNotPropagate; }
   });
 };
 


### PR DESCRIPTION
I wrote a small fix for a bug I encountered. skipFirstE skipped every event instead of just skipping the first one. I used the boolean already in the closure to enable the intended behaviour.
